### PR TITLE
Re-introduce `cmd_var`

### DIFF
--- a/cmd
+++ b/cmd
@@ -76,6 +76,12 @@ function cmd_confirm {
   cmd_ask "$prompt" >/dev/null
 }
 
+function cmd_var {
+  # args: var [prompt]
+  # Reads variable $var. If unset, prompts the user interactively.
+  echo "${!1-$(cmd_ask "${2-"$1:"}")}" # don't extract vars to avoid collisions
+}
+
 # VALIDATION #
 
 function _cmd_validate_path_from_root {

--- a/test.sh
+++ b/test.sh
@@ -267,6 +267,57 @@ function test_cmd_confirm {
   assertEquals '' "$out"
 }
 
+function test_cmd_var {
+  local out
+  # Existing, nonempty var.
+  out=$(my_var=hello cmd --eval 'cmd_var my_var' 2>/dev/null)
+  assertEquals 0 $?
+  assertEquals 'hello' "$out"
+  # Existing, empty var.
+  out=$(my_var= cmd --eval 'cmd_var my_var' 2>/dev/null)
+  assertEquals 0 $?
+  assertEquals '' "$out"
+  # Nonexisting var; value provided on stdin.
+  out=$(echo 'my_val' | cmd --eval 'cmd_var my_var' 2>/dev/null)
+  assertEquals 0 $?
+  assertEquals 'my_val' "$out"
+  # ... with custom prompt.
+  out=$(echo 'my_val' | cmd --eval 'cmd_var my_var "Enter:"' 2>/dev/null)
+  assertEquals 0 $?
+  assertEquals 'my_val' "$out"
+  # Empty value provided.
+  out=$(echo | cmd --eval 'cmd_var my_var' 2>/dev/null)
+  assertEquals 0 $?
+  assertEquals '' "$out"
+  # Define local var that didn't exist previously.
+  out=$(my_var=hello cmd --eval 'local my_var="$(cmd_var my_var)"; echo "$my_var"' 2>/dev/null)
+  assertEquals 0 $?
+  assertEquals 'hello' "$out"
+  # Define previously unset local var.
+  out=$(echo 'my_val' | cmd --eval 'local my_var="$(cmd_var my_var)"; echo "$my_var"' 2>/dev/null)
+  assertEquals 0 $?
+  assertEquals 'my_val' "$out"
+  # Define previously existing local var.
+  out=$(echo 'my_val' | my_var=our_val cmd --eval 'echo "$my_var"; local my_var="$(cmd_var my_var)"; echo "$my_var"' 2>/dev/null)
+  assertEquals 0 $?
+  assertEquals $'our_val\nour_val' "$out"
+  # ... which may be internal.
+  out=$(cmd --eval 'echo "$cmd_command"; local my_var="$(cmd_var cmd_command)"; echo "$cmd_command"' 2>/dev/null)
+  assertEquals 0 $?
+  assertEquals $'cmd\ncmd' "$out"
+  # Var names don't collide with cmd_ask's internal locals ('prompt', 'default', 'r').
+  out=$(prompt=foo default=bar r=baz cmd --eval 'echo "$(cmd_var prompt)#$(cmd_var default)#$(cmd_var r)"' 2>/dev/null)
+  assertEquals 0 $?
+  assertEquals 'foo#bar#baz' "$out"
+  # Positional args leak (don't use)...
+  out=$(echo x | cmd --eval 'cmd_var 1' 2>/dev/null)
+  assertEquals 0 $?
+  assertEquals '1' "$out"
+  out=$(echo x | cmd --eval 'cmd_var 2' 2>/dev/null)
+  assertEquals 0 $?
+  assertEquals 'x' "$out"
+}
+
 function test_which {
   local out
   out=$(cmd --which hello 2>&1)


### PR DESCRIPTION
The function previously existed as `cmd_var <var> [prompt]`, but was modified and renamed to `cmd_ask` in 3f2aae5. This function was changed in the previous commit (0dc740b), dropping the variable part, thus preparing the ground for re-introducing `cmd_var` once a few proper use cases have been identified. We still don't modify the variable (though we easily could using `printf -v`) for the same reason it was originally changed (it doesn't work with `local`). That is, the use should be:

```bash
local my_var="$(cmd_var my_var "Input:")"
```

(the prompt "Input:" being optional, defaulting to `"$var:"`). The expected use case is a giving the user the ability to provide certain information programmatically through optional variables, falling back to interactive input if they're missing.

Other than being a minor convenience on top of `cmd_ask`, it could be extended to record the variables. A function could then dump the command required to continue the scripts from where it was (like as part of the script does a voluntary premature exit or in an interrupt handler) by including those variables.

Resolves #9 (again).